### PR TITLE
Add templates for issue, feature-request and pull request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--- Filling this template is mandatory -->
+
+**Detailed description**
+
+<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
+
+...
+
+**Test plan**
+
+<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->
+
+...
+
+**Closing issues**
+
+<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
+
+...

--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Report a bug or an issue to help us improve our project
+---
+<!--- Filling this template is mandatory -->
+<!--- Provide a general summary of the issue in the Title above -->
+
+**Describe the issue**
+
+<!-- A clear description of what the bug is. -->
+
+**How to reproduce?**
+
+<!-- Tell us how to reproduce this issue. Please provide a demo or a set of steps that we need to take. -->
+
+
+**Expected behavior**
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Possible fix**
+
+<!-- Not obligatory, but suggest a fix or reason for the bug -->
+
+**Screenshots**
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+
+**Additional context**
+
+<!-- Attach relevant files or add any other context about the problem here. -->

--- a/ISSUE_TEMPLATE/feature_request.md
+++ b/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+
+---
+<!--- Filling this template is mandatory -->
+<!--- Provide a general summary of the issue in the Title above -->
+
+**Is your feature request related to a problem? Please describe**
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+
+<!-- Provide a detailed description of the change or addition you are proposing.
+For UI requests, don't hesitate to post some draws. -->
+
+**Possible Implementation**
+
+<!--- Not obligatory, but suggest an idea for implementing addition or change -->
+
+**Describe alternatives you've considered**
+
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Detailed description**
The following Pull request is adding general templates for issues and pull-requests across the Radareorg repositories. These additions are followed by the [Creating a default community health file](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file) article.

These templates will only affect the repositories that do not have such templates on their `.github` folder.

> GitHub will use and display default files for any public repository owned by the account that does not have its own file of that type in any of the following places:

Additions:
- Generic Pull Request template
- Generic Bug Report template
- Generic Feature Request template

**Test plan**
- Verify that everything explained correctly in the templates. Check grammar and typos.
- Check that nothing important was omitted from these templates. While I tried to keep it minimal, some things could have been missed.


**Closing issues**

None